### PR TITLE
Added install scripts

### DIFF
--- a/cc_utils/install
+++ b/cc_utils/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+

--- a/ccsd_space_orb/install
+++ b/ccsd_space_orb/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+

--- a/coupled_cluster/install
+++ b/coupled_cluster/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+

--- a/localization/install
+++ b/localization/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+

--- a/orbital_optimization/install
+++ b/orbital_optimization/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+

--- a/trust_region/install
+++ b/trust_region/install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the QP_ROOT environment variable is set.
+if [[ -z ${QP_ROOT} ]]
+then
+  print "The QP_ROOT environment variable is not set."
+  print "Please reload the quantum_package.rc file."
+  exit -1
+fi
+
+which emacs
+if [[ $? -ne 0 ]] ; then
+   echo "Please install Emacs to generate the source code"
+   exit 1
+fi
+
+for element in *.org
+do
+  emacs --batch $element -f org-babel-tangle
+done
+


### PR DESCRIPTION
Whe you run
```
qp plugin install pouet
```
there can be an install script in the `pouet` module to perform actions before installing, like copying scripts into `$QP_ROOT/scripts` or checking the environment.
I have added install scripts that tangle the org-mode files when the modules are installed.

Similarly, you can have an `uninstall` scripts that performs some actions when the plugin is uninstalled.